### PR TITLE
Add a template PR file

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+# Description
+
+Please include a summary of the changes and the related issue. Please also include relevant motivation, and describe how that change affects the application.
+
+Fixes # (issue)
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+# How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce and the output. Please also list any relevant details for your test configuration
+
+# Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules
+


### PR DESCRIPTION
# Description

This change creates `.github/pull_request_template.md` providing a pull request template for all future PRs moving forward. This will help us address all the requirements needed when creating a new PR each time.

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I did a preview of the markdown and it looks good
<img width="843" alt="Screenshot 2025-02-13 at 5 42 10 PM" src="https://github.com/user-attachments/assets/9e246844-f1e9-4e07-8773-bf883c2152fe" />

I followed the [Github Docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) to create this, so it should work.

